### PR TITLE
casino5: fixed mafia driver not driving

### DIFF
--- a/main/story_missions/Vegas/casino5.sc
+++ b/main/story_missions/Vegas/casino5.sc
@@ -1118,6 +1118,7 @@ mission_casino5_SUB_setup_mafia_ambulance:
 		GIVE_WEAPON_TO_CHAR driver_C5[mafia_ID_C5] WEAPONTYPE_MP5 30000
 		SET_CURRENT_CHAR_WEAPON driver_C5[mafia_ID_C5] WEAPONTYPE_MP5
 		SET_CHAR_DECISION_MAKER driver_C5[mafia_ID_C5] tough_dm_C5
+		TASK_CAR_DRIVE_WANDER driver_C5[mafia_ID_C5] ambulance_C5[mafia_ID_C5] 15.0 DRIVINGMODE_STOPFORCARS // FIXEDGROVE: otherwise will be stuck in place
 
 		// mafia passenger
 		IF NOT IS_CHAR_DEAD passenger_C5[mafia_ID_C5]

--- a/readme.md
+++ b/readme.md
@@ -278,6 +278,7 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 - Fixed right handbrake turns not counting 
 
 **Intensive Care:**
+- Fixed mafia driver not driving
 - Increased upper bound in a random number generator, bringing back an unintentionally unused random car plate
 
 **Up, Up And Away!:**


### PR DESCRIPTION
After you ram in the first ambulance, one of the other drivers would get swapped with a mafia one, but the car will be stuck in place (until you ram into it)

Made it so it drives like the other ones