### PR TITLE
cat4: made first cutscene able to skip and made a black screen shorter

### DIFF
--- a/main/story_missions/Badlands/cat4.sc
+++ b/main/story_missions/Badlands/cat4.sc
@@ -1205,6 +1205,7 @@ SET_PED_DENSITY_MULTIPLIER 0.0
 
 
 		IF flag_cutscene1_cat4 = 1
+		SKIP_CUTSCENE_START // FIXEDGROVE
 
 			IF NOT IS_CHAR_DEAD catalina
 			  //	CLEAR_CHAR_TASKS catalina
@@ -1370,6 +1371,7 @@ SET_PED_DENSITY_MULTIPLIER 0.0
 
 
 			IF TIMERB > 10000
+				SKIP_CUTSCENE_END // FIXEDGROVE
 				flag_cutscene1_cat4 = 10
 			ENDIF
 
@@ -1377,6 +1379,15 @@ SET_PED_DENSITY_MULTIPLIER 0.0
 			CLEAR_MISSION_AUDIO 1
 			flag_cutscene1_cat4 = 10
 		ENDIF
+
+		// FIXEDGROVE: START
+		IF flag_cutscene1_cat4 = 10
+			CLEAR_MISSION_AUDIO 1
+			IF NOT IS_CHAR_DEAD catalina
+				CLEAR_CHAR_TASKS catalina
+			ENDIF
+		ENDIF
+		// FIXEDGROVE: END
 
 	ENDWHILE
 
@@ -2360,6 +2371,7 @@ SET_PED_DENSITY_MULTIPLIER 0.0
 
 		IF flag_safe_explosion_delay = 1
 			IF TIMERA > 500
+				CLEAR_PRINTS // FIXEDGROVE
 				ADD_EXPLOSION 820.5 9.7 1003.2164 EXPLOSION_GRENADE
 
 				index_cat4 = 4
@@ -2685,8 +2697,13 @@ SET_PED_DENSITY_MULTIPLIER 0.0
 					//	ENDIF
 					ENDIF
 
-
-					
+					// FIXEDGROVE: START - added to make black screen time shorter
+					IF flag_cutscene1_cat4 = 5
+						IF TIMERA > 1000
+							flag_cutscene1_cat4 = 10
+						ENDIF
+					ENDIF
+					// FIXEDGROVE: END
 
 					IF TIMERB > 14800
 						flag_cutscene1_cat4 = 10

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,10 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 **Small Town Bank:**
 - Fixed facial talk anim
 
+**Against All Odds:**
+- Added ability to skip first cutscene after the first voiceline played
+- Made the black screen before exiting the interior in cutscene shorter
+
 **Big Smoke's Cash:**
 - Fixed mission cancelling suddenly if player gets a phonecall
 - Courier blip is only added if the mission was accepted


### PR DESCRIPTION
the first cutscene could only be skipped while the voice lines weren't playing, made it able to skip after the first one played

the cutscene when exiting the interior didn't 'end' properly, it was stuck on a black screen until a failsafe timer ended