### PR TITLE
Fixed help text timing so it can show up properly

### DIFF
--- a/main/story_missions/LA1/intro1.sc
+++ b/main/story_missions/LA1/intro1.sc
@@ -34,6 +34,7 @@ LVAR_INT smokes_decision sweets_decision ryders_decision skip_funeral_cutscene s
 LVAR_INT intro1_cutscene_flag chars_decision drive_to_hub_smoke	set_up_smokes_audio flag_the_drive_by_car_is_dead killed_the_baller_cunts play_catch_up_audio
 LVAR_FLOAT int1X int1Y int1Z  ClosestX ClosestY ClosestZ int1_driveX int1_driveY int1_driveZ player_bmxX player_bmxY player_bmxZ
 LVAR_INT int1_char_model[3] int1_char_select // FIXEDGROVE
+LVAR_INT timer_start timer_end // FIXEDGROVE
 VAR_TEXT_LABEL $intro1_chat[14]
 
 intro1_chat_switch:
@@ -1262,38 +1263,50 @@ OR NOT LOCATE_CHAR_ANY_MEANS_3D bmx_gang[2] 1644.7734 -1051.3339 22.8984 10.0 12
 	// ***************************************************************************************************************
 	// ***************************************BMX HELP TEXT***********************************************************
 	
-	IF IS_CHAR_IN_MODEL scplayer BMX 
-		
-		IF been_in_a_bmx = 0
-			PRINT_HELP INTRO2C 
-			
-			TIMERA = 0
-			been_in_a_bmx = 1
-		
-		ELSE
-			IF been_in_a_bmx = 1
-				IF TIMERA > 10000
-					
-					PRINT_HELP INTRO2D  
-					
-					TIMERA = 0
+	IF IS_CHAR_IN_MODEL scplayer BMX
+	// FIXEDGROVE: START - change to switch-case and don't use TIMERA
+		SWITCH been_in_a_bmx
+		CASE 0
+			IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
+				PRINT_HELP INTRO2C
+				been_in_a_bmx = 1
+				GET_GAME_TIMER timer_start
+				timer_start = timer_start + 10000
+			ENDIF
+		BREAK
+		CASE 1
+			IF timer_end > timer_start //IF TIMERA > 10000
+				IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
+					PRINT_HELP INTRO2D
 					been_in_a_bmx = 2
+					GET_GAME_TIMER timer_start
+					timer_start = timer_start + 10000
 				ENDIF
 			ENDIF
-			
-			IF been_in_a_bmx = 2
-				IF TIMERA > 20000
+		BREAK
+		CASE 2
+			IF timer_end > timer_start //IF TIMERA > 20000
+				IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
 					PRINT_HELP HELP3B // You can only cycle fast or sprint for a limited amount of time. 
 					been_in_a_bmx = 3
-					ENDIF
+					GET_GAME_TIMER timer_start
+					timer_start = timer_start + 8000
+				ENDIF
 			ENDIF
-			IF been_in_a_bmx = 3
-				IF TIMERA > 28000
+		BREAK
+		CASE 3
+			IF timer_end > timer_start //IF TIMERA > 28000
+				IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
 					PRINT_HELP HELP3B2  // The more exercise you get the higher your ~h~stamina~w~ will become, allowing you to exert yourself for longer.  
 					been_in_a_bmx = 4
 				ENDIF
 			ENDIF
+		BREAK
+		ENDSWITCH
+		IF been_in_a_bmx < 4
+			GET_GAME_TIMER timer_end
 		ENDIF
+	// FIXEDGROVE: END
 	ENDIF
 
 

--- a/main/story_missions/LA1/sweet2.sc
+++ b/main/story_missions/LA1/sweet2.sc
@@ -32,6 +32,7 @@ LVAR_INT smoke_sweet2_seq_3	smoke_idle_seq2	smoke_idle_seq big_smoke_group_spilt
 LVAR_INT sweet2_audio_chat[14] sweet2_index	sweet2_audio_is_playing	sweet2_cutscene_flag emmets_car	refresh_char_weapon	finished_mobile_phone_call
 LVAR_INT new_visible_area print_help_sweet2	skip_emmets_cutscene
 LVAR_FLOAT beer_bottleX[5] beer_bottleY[5] beer_bottleZ[5]
+LVAR_INT timer_start timer_end // FIXEDGROVE
 VAR_TEXT_LABEL $sweet2_chat[14]
 
 // **************************************** Mission Start **********************************
@@ -2448,47 +2449,66 @@ UNLOAD_SPECIAL_CHARACTER 1
 
 //skip_hereeeeeeeeeeeeeeee:
 
+GET_GAME_TIMER timer_start // FIXEDGROVE
+timer_start = timer_start + 2000 // FIXEDGROVE
+
 WHILE NOT LOCATE_CAR_3D big_smoke_car 2066.4648 -1695.4436 12.5547 4.0 4.0 4.0 blob_flag //GO to Smokes
 OR NOT IS_CHAR_SITTING_IN_CAR big_smoke big_smoke_car
 OR NOT IS_VEHICLE_ON_ALL_WHEELS	big_smoke_car
 	WAIT 0
 
 		
-	IF NOT IS_CHAR_IN_ANY_CAR scplayer
-		IF TIMERA > 5000
-			IF gun_help = 1
-				
-				PRINT_HELP HELP53  
-				
-				TIMERA = 0
-				gun_help = 2
-			ENDIF
-		ENDIF
-		IF TIMERA > 5000
-			IF gun_help = 2
-				PRINT_HELP ( HOOD2D )  // Your ~h~gun stat~w~ will increase the more you use your weapon.
-				TIMERA = 0
-				gun_help = 3
-			ENDIF
-		ENDIF
-		IF TIMERA > 5000
-			IF gun_help = 3
-				PRINT_HELP ( HOOD2E )  
-				TIMERA = 0
-				gun_help = 4
-			ENDIF
-		ENDIF
-	ELSE
-		IF TIMERA > 2000
-			IF gun_help = 0
+	// FIXEDGROVE: START - change from if-chain to switch-case and don't use TIMERA
+	// IF NOT IS_CHAR_IN_ANY_CAR scplayer // FIXEDGROVE: comment out
+	SWITCH gun_help
+	CASE 0
+		IF timer_end > timer_start //IF TIMERA > 2000
+			IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
 				PRINT_HELP ( EMMET_G ) // Get guns from Emmet.
 				REMOVE_BLIP emmets_shop_blip
 				ADD_SHORT_RANGE_SPRITE_BLIP_FOR_COORD 2447.3643 -1974.4963 12.5469 RADAR_SPRITE_EMMETGUN emmets_shop_blip //Emmet
-				TIMERA = 0
 				gun_help = 1
+				GET_GAME_TIMER timer_start
+				timer_start = timer_start + 5000
 			ENDIF
 		ENDIF
+	BREAK
+	CASE 1
+		IF timer_end > timer_start //IF TIMERA > 5000
+			IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
+				IF NOT IS_CHAR_IN_ANY_CAR scplayer // FIXEDGROVE: added check because you can't switch weapons in a vehicle
+					PRINT_HELP HELP53  
+				ENDIF // FIXEDGROVE
+				gun_help = 2
+				GET_GAME_TIMER timer_start
+				timer_start = timer_start + 5000
+			ENDIF
+		ENDIF
+	BREAK
+	CASE 2
+		IF timer_end > timer_start //IF TIMERA > 5000
+			IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
+				PRINT_HELP ( HOOD2D )  // Your ~h~gun stat~w~ will increase the more you use your weapon.
+				gun_help = 3
+				GET_GAME_TIMER timer_start
+				timer_start = timer_start + 5000
+			ENDIF
+		ENDIF
+	BREAK
+	CASE 3
+		IF timer_end > timer_start //IF TIMERA > 5000
+			IF NOT IS_HELP_MESSAGE_BEING_DISPLAYED
+				PRINT_HELP ( HOOD2E )  
+				gun_help = 4
+			ENDIF
+		ENDIF
+	BREAK
+	ENDSWITCH
+	IF gun_help < 4
+		GET_GAME_TIMER timer_end
 	ENDIF
+	// FIXEDGROVE: END
+	//ENDIF // FIXEDGROVE: comment out
 
 	IF NOT IS_CHAR_DEAD	big_smoke
 		IF NOT IS_CAR_DEAD big_smoke_car

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 - Made Groves hate scripted ballas
 - Made Ballas respect scripted ballas
 - Changed Ballas' models to be random
+- Fixed the help text for BMX so it can show up while dialogue is happening
 
 **Ryder:**
 - Fixed Ryder's car spawning only being turned ON on mission pass
@@ -75,6 +76,7 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 
 **Nines And AKs:**
 - Made "cycling through targets" help box only show up if using a controller, otherwise display unused help box about gun recoil
+- Restored help text about weapons while going to Smoke's place
 
 **Drive-By:**
 - Fixed player floating a bit at the start of the mission


### PR DESCRIPTION
in intro1 and sweet2, changed `TIMERA` for a custom one because `TIMERA` is used elsewhere too
for intro1 they'd all show up if you sit around after all the dialogue finishes, instead of one after the other as it may have been intended
for sweet2 they only show up if player is not in a car, so I removed that check but kept it for one of the help texts because it mentions weapon switching (can't do that in a car)