### PR TITLE
player_parachute: added an extra check so it doesn't get stuck

### DIFF
--- a/main/oddjobs/location/player_parachute.sc
+++ b/main/oddjobs/location/player_parachute.sc
@@ -727,11 +727,16 @@ jump_loop:
 
 						GET_OBJECT_ANIM_CURRENT_TIME parac para_land_o para_f1
 						IF para_f1 = 1.0 
-	//				IF TIMERA > para_time_check
 							player_landed = 2
-
 							GOSUB parachute_cleanup
 						ENDIF
+					// FIXEDGROVE: START - check if the anim stops before it finishes, avoids script getting stuck
+					ELSE
+						IF TIMERA > para_time_check // uncomment
+							player_landed = 2
+							GOSUB parachute_cleanup
+						ENDIF
+					// FIXEDGROVE: END
 					ENDIF
 				ENDIF
 			ENDIF
@@ -739,14 +744,20 @@ jump_loop:
 			IF player_fall_state = 5
 				player_landed = 1
 				IF code_flag = 0
-					//FIXEDGROVE: START - uncomment parachute animation check to allow full anim to play
+					// FIXEDGROVE: START - uncomment parachute animation check to allow full anim to play
 					IF IS_OBJECT_PLAYING_ANIM parac para_land_water_o
 						GET_OBJECT_ANIM_CURRENT_TIME parac para_land_water_o para_f1
 						IF para_f1 = 1.0
-	//				IF TIMERA > para_time_check
 							player_landed = 2
 							GOSUB parachute_cleanup
 						ENDIF
+					// FIXEDGROVE: START - check if the anim stops before it finishes, avoids script getting stuck
+					ELSE
+						IF TIMERA > para_time_check // uncomment
+							player_landed = 2
+							GOSUB parachute_cleanup
+						ENDIF
+					// FIXEDGROVE: END
 					ENDIF		
 				ENDIF			
 			ENDIF

--- a/readme.md
+++ b/readme.md
@@ -433,6 +433,7 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 - Fixed a bug where the parachute "fails to open" if you have the "keep weapons after death" bonus and you die with a parachute in your inventory
 - Fixed weird twitch after landing
 - Fixed parachute going through the floor
+- Fixed a bug that would make it not possible to switch weapons if you started a mission while landing with the parachute
 - Uncommented some code to allow the full "landing in water" anim for parachute to play
 
 **Misc:**


### PR DESCRIPTION
if you start a mission while landing, it'd get stuck checking if the animation is playing (starting a mission makes that animation stop)