### PR TITLE
boat: teleport player so they're not in the boat before removing it

### DIFF
--- a/main/oddjobs/location/boat.sc
+++ b/main/oddjobs/location/boat.sc
@@ -6297,6 +6297,17 @@ RETURN
 // Mission boat failed
 
 mission_boat_failed:
+// FIXEDGROVE: START - fade out and teleport player
+DO_FADE 500 FADE_OUT
+WHILE GET_FADING_STATUS
+	WAIT 0
+ENDWHILE
+IF IS_CHAR_IN_ANY_CAR scplayer 
+	WARP_CHAR_FROM_CAR_TO_COORD scplayer boat_playerstartx boat_playerstarty boat_playerstartz
+ELSE
+	SET_CHAR_COORDINATES scplayer boat_playerstartx boat_playerstarty boat_playerstartz
+ENDIF
+//FIXEDGROVE: END
 
 
 LOAD_SCENE_IN_DIRECTION	-2185.3347 2410.4092 3.9752 122.2585 
@@ -6309,6 +6320,12 @@ SET_CHAR_HEADING scplayer boat_playerstarth
 SET_CAMERA_BEHIND_PLAYER
 RESTORE_CAMERA_JUMPCUT
 
+// FIXEDGROVE: START
+DO_FADE 500 FADE_IN
+WHILE GET_FADING_STATUS
+	WAIT 0
+ENDWHILE
+// FIXEDGROVE: END
 RETURN
 
    

--- a/main/oddjobs/location/boat.sc
+++ b/main/oddjobs/location/boat.sc
@@ -571,6 +571,15 @@ WAIT 0
 
 			//quitting the boat school
 			IF IS_BUTTON_PRESSED PAD1 BUTTON_CANCEL // FIXEDGROVE: use button variables instead of copypasted code for JP version
+
+				// FIXEDGROVE: START
+				DO_FADE 500 FADE_OUT
+				WHILE GET_FADING_STATUS
+					WAIT 0
+					GOSUB boat_drawing_tv_screen
+				ENDWHILE
+				// FIXEDGROVE: END
+
 				GOTO mission_boat_failed
 			ENDIF
 
@@ -6298,10 +6307,13 @@ RETURN
 
 mission_boat_failed:
 // FIXEDGROVE: START - fade out and teleport player
-DO_FADE 500 FADE_OUT
-WHILE GET_FADING_STATUS
-	WAIT 0
-ENDWHILE
+IF instructor_boat_dead_flag = 1
+	DO_FADE 500 FADE_OUT
+	WHILE GET_FADING_STATUS
+		WAIT 0
+	ENDWHILE
+ENDIF
+
 IF IS_CHAR_IN_ANY_CAR scplayer 
 	WARP_CHAR_FROM_CAR_TO_COORD scplayer boat_playerstartx boat_playerstarty boat_playerstartz
 ELSE

--- a/readme.md
+++ b/readme.md
@@ -466,6 +466,7 @@ Extract the downloaded .zip file and replace main.scm and scripts.img inside dat
 - Fixed barber animation jump if the player has a previewed haircut and they quit out of the shop
 - Fixed badly positioned 'no medal' sprite in Driving School introduced in JP version development
 - Fixed camera not resetting instantly after quitting Bike School
+- Fixed Boat School to not despawn the player if they flip a boat in water
 - Fixed 'The Green Sabre' not switching on traffic to Flint County bridges
 - Fixed 'T-Bone Mendez' erroneously switching on the Easter Basin highway traffic before the barriers were removed
 - Fixed Flint Intersection and Flint Range zones being assigned the desert popcycle instead of the countryside one


### PR DESCRIPTION
also made it fade out/in while exiting (but the TV borders don't show up, didn't look into how it's done yet). I could try to also include the fade in bike school

may fix #13